### PR TITLE
Made sure recipe excess was being used by MixtureMaterial class

### DIFF
--- a/murraylab_tools/echo/echo_functions.py
+++ b/murraylab_tools/echo/echo_functions.py
@@ -1450,10 +1450,10 @@ class MixtureMaterial(AbstractMixture, EchoSourceMaterial):
         ret_str = "\n%s:" % (self.name)
         ret_str += "\n\tStock Concentration: %d %s" % (self.concentration,
                                                        self.units)
-        ret_str += "\n\tTotal Volume: %.2f" % (self.get_volume())
+        ret_str += "\n\tTotal Volume: %.2f" % (self.get_volume()*self.recipe_excess)
         lines = []
         for material, volume in self.recipe():
-            lines.append("\n\t\t%0.2f uL %s" % (volume/1000, str(material)))
+            lines.append("\n\t\t%0.2f uL %s" % (volume/1000*self.recipe_excess, str(material)))
         return ret_str + "".join(lines)
 
     def get_volume(self):


### PR DESCRIPTION
Changed text_recipe() in MixtureMaterial class so that it actually uses the recipe_excess attribute (currently it does not use it for anything I think...).